### PR TITLE
feat: add metadata caching

### DIFF
--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,44 @@
+export interface CacheEntry<T> {
+  value: T;
+  expires: number;
+}
+
+export class LRUCache<T> {
+  private cache = new Map<string, CacheEntry<T>>();
+
+  constructor(
+    private maxSize: number,
+    private ttl: number,
+  ) {}
+
+  get(key: string): T | undefined {
+    const entry = this.cache.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expires) {
+      this.cache.delete(key);
+      return undefined;
+    }
+    // refresh LRU order
+    this.cache.delete(key);
+    this.cache.set(key, entry);
+    return entry.value;
+  }
+
+  set(key: string, value: T): void {
+    const entry: CacheEntry<T> = { value, expires: Date.now() + this.ttl };
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    }
+    this.cache.set(key, entry);
+    if (this.cache.size > this.maxSize) {
+      const firstKey = this.cache.keys().next().value;
+      if (firstKey !== undefined) {
+        this.cache.delete(firstKey);
+      }
+    }
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+}


### PR DESCRIPTION
## Summary
- add generic LRU cache utility
- cache file metadata in filesystem helper with env-configurable size and TTL
- test metadata caching behavior

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b94dbbace0832bb091d64d5d60aa5a