### PR TITLE
docs: document caching and filesystem differences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # Repository Guidelines
 
+DocFS is a read-only filesystem MCP server with multiple root support, `.gitignore` filtering, and an
+in-memory LRU cache for file metadata. Compared to a generic filesystem MCP server, it offers only
+inspection tools and strictly validates paths against the configured roots.
+
 ## MCP Tools for Agents
 
 - `list_files`: list files and directories

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DocFS
 
-DocFS is a Model Context Protocol (MCP) server that exposes read-only file system tools to MCP clients. Requires Node.js 18 or later.
+DocFS is a Model Context Protocol (MCP) server that exposes read-only file system tools to MCP clients. It supports multiple root directories, filters paths using `.gitignore`, and caches file metadata in an in-memory LRU cache for faster access. Requires Node.js 18 or later.
 
 ## Tools
 
@@ -8,6 +8,15 @@ DocFS is a Model Context Protocol (MCP) server that exposes read-only file syste
 - `list_files` – list directories and files
 - `search_files` – search text across files
 - `read_files` – read file contents
+
+## Differences from a generic filesystem MCP server
+
+DocFS trades the broader read/write capabilities of a standard filesystem server for a narrower, read-only feature set with extra safety and convenience features:
+
+- Read-only operations only
+- Limited to `dir_tree`, `list_files`, `search_files`, and `read_files`
+- Enforces one or more user-specified root directories
+- Applies `.gitignore` rules and caches file metadata using an in-memory LRU cache
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- document LRU caching and `.gitignore` filtering in README and AGENTS guidelines
- add section outlining DocFS vs generic filesystem MCP server

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b95b40fe88832bb7a18398de7674d9